### PR TITLE
Disable strict dict to load more models

### DIFF
--- a/llama_inference_offload.py
+++ b/llama_inference_offload.py
@@ -233,9 +233,9 @@ def load_quant(model, checkpoint, wbits, groupsize, pre_layer):
     print('Loading model ...')
     if checkpoint.endswith('.safetensors'):
         from safetensors.torch import load_file as safe_load
-        model.load_state_dict(safe_load(checkpoint))
+        model.load_state_dict(safe_load(checkpoint), strict=False)
     else:
-        model.load_state_dict(torch.load(checkpoint))
+        model.load_state_dict(torch.load(checkpoint), strict=False)
     model.seqlen = 2048
     
     if (isinstance(pre_layer, int)):


### PR DESCRIPTION
Closes issues like https://github.com/oobabooga/text-generation-webui/issues/2434

I also had issues with a 65b model until I did this.